### PR TITLE
TSR-10 Added duplicate protection when creating routes.

### DIFF
--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,1 +1,2 @@
 export {default as SmsService} from "./smsService";
+export {default as ToastService} from "./toastService";

--- a/src/services/toastService.ts
+++ b/src/services/toastService.ts
@@ -1,0 +1,7 @@
+import {ToastAndroid} from "react-native";
+
+export default class ToastService {
+    static show(message: string): void {
+        ToastAndroid.show(message, ToastAndroid.SHORT);
+    }
+}


### PR DESCRIPTION
Changelog:

- Users are now prevented from creating duplicate routes, and are notified of such with a toast.

Implementation Details:

- Modified the `createRoute` saga to handle duplicate checking.
- Also modified it to show a toast using the new Toast service so that the user knows what happened.